### PR TITLE
Encrypt cookies with AES in CBC mode and external HMAC

### DIFF
--- a/stateless-cookie-crypto.md
+++ b/stateless-cookie-crypto.md
@@ -31,7 +31,7 @@ Question: Should server send remove-cookie for oldest cookies to the client if t
 
 ## crypto
 
-Encryption will be done with AESGCM which is an AEAD algorithm that provides both verification and encyrption at the same time.
+Encryption will be done with AES in CBC mode with a changing initialization vector and both the ciphertext and and the iv will be protected from modification with a SHA-512 HMAC.
 The speed (or slowness) of the chosen algorithm will not matter since the cookies will be relatively long lived and the server will cache the seen valid cookies in memory.
 
 *Q: what about often-changing "custom application state"; some requests may specify some previous cookie value; should we perhaps keep the last two(?) cookie values in the cache?*
@@ -43,7 +43,7 @@ Deflate is better than gzip because deflate omits the header and checksum. Espec
 
 ## final cookie encoding
 
-`base64(AESGCM(deflate(utf8bytes("key=value|key2=value|..."))))`
+`base64(AESCBCwithSHA512HMAC(deflate(utf8bytes("key=value|key2=value|..."))))`
 
 ## security evaluation
 


### PR DESCRIPTION
Switch AES GCM mode to CBC + SHA-512 HMAC when encrypting cookies.

### Rationale

GCM nonces **must**  be unique across all ciphertexts ever encrypted with the same key, otherwise the encryption is broken. As stepping in the same river is the only thing in the world you can do exactly once, producing nonces that are **guaranteed** to remain unique is pretty much impossible.

AES in GCM mode on the JVM is also much less battle-tested than CBC. For example, a timing attack vulnerability was present until 8u51. Also, though insignificant in this case, CBC has intrinsics but for GCM these are not available [until Java 9](http://openjdk.java.net/jeps/246).

### Implementation

Encrypt cookies with AES in CBC mode with a constantly changing initialization vector. Create a SHA-512 HMAC from both the iv and the ciphertext. The final encrypted byte array is thus
- hmac_sha512(iv + ciphertext) => 64 bytes
- iv => 16 bytes
- aes_cbc(iv, plaintext) => N bytes

When decrypting cookies, only timing attack safe comparisons are used and all errors in decryption produce the exact same exception.
